### PR TITLE
BUGFIX: fatal error exception not found

### DIFF
--- a/Elasticsearch/ClientRequest.php
+++ b/Elasticsearch/ClientRequest.php
@@ -73,7 +73,7 @@ class ClientRequest
         $hits = $search['hits'];
         
         if (1 != $hits['total']) {
-            throw new Exception(sprintf('expected 1 result, got %d', $hits['total']));
+            throw new \Exception(sprintf('expected 1 result, got %d', $hits['total']));
         }
         
         return $hits['hits'][0];


### PR DESCRIPTION
php.CRITICAL: Fatal Error: Class 'EMS\ClientHelperBundle\Elasticsearch\Exception' not found {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalErrorException(code: 0): Error: Class 'EMS\\ClientHelperBundle\\Elasticsearch\\Exception' not found at C:\\xampp\\htdocs\\ehealthportal\\contrib\\src\\vendor\\elasticms\\client-helper-bundle\\Elasticsearch\\ClientRequest.php:76)"}