### PR TITLE
BUGFIX: missing parameter in services.xml

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -30,11 +30,6 @@
             <argument type="service" id="translator" />
             <argument type="service" id="emsch.request.service" />
             <tag name="twig.extension" />
-        </service>    
-        <service id="emsch.twig.extension.routing" class="%emsch.twig.extension.routing.class%">
-            <argument type="service" id="router" />
-            <argument type="service" id="emsch.request.service" />
-            <tag name="twig.extension" />
         </service>
                         
         <!-- elasticsearch services -->


### PR DESCRIPTION
PHP Fatal error:  Uncaught exception
'Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException'
with message 'The service "emsch.twig.extension.routing" has a
dependency on a non-existent parameter