### PR TITLE
BUGFIX: empty request fatal error

### DIFF
--- a/EMSBackendBridgeBundle/Service/RequestService.php
+++ b/EMSBackendBridgeBundle/Service/RequestService.php
@@ -24,6 +24,10 @@ class RequestService
      */
     public function getEnvironment()
     {
+        if (null === $this->requestStack->getCurrentRequest()) {
+            return '';
+        }
+        
         return $this->requestStack->getCurrentRequest()->get('_environment');
     }
     
@@ -32,6 +36,10 @@ class RequestService
      */
     public function getLocale()
     {
+        if (null === $this->requestStack->getCurrentRequest()) {
+            return '';
+        }
+        
         return $this->requestStack->getCurrentRequest()->get('_locale');
     }
 }


### PR DESCRIPTION
on cache clear without warmup

 PHP Fatal error:  Call to a member function get() on null in
 C:\xampp\htdocs\ehealthplatform\contrib\src\vendor\elasticms\client-helper-bundle\EMSBackendBridgeBundle\Service\RequestService.php
 on line 27