### PR TITLE
Fix getting locale from symfony request

### DIFF
--- a/EMSBackendBridgeBundle/Service/RequestService.php
+++ b/EMSBackendBridgeBundle/Service/RequestService.php
@@ -36,6 +36,6 @@ class RequestService
     {
         $current = $this->requestStack->getCurrentRequest();
         
-        return ($current ? $current->get('_locale') : null);
+        return ($current ? $current->getLocale() : null);
     }
 }


### PR DESCRIPTION
Use getLocale() instead of get('_locale')