### PR TITLE
Bugfix: api controller

### DIFF
--- a/EMSBackendBridgeBundle/Controller/ApiController.php
+++ b/EMSBackendBridgeBundle/Controller/ApiController.php
@@ -38,7 +38,7 @@ class ApiController extends AbstractController
     {
         $scrollId = $request->query->get('scroll');
         $size = $request->query->get('size');
-        $filter = $request->query->get('filter');
+        $filter = $request->query->get('filter', []);
 
         return $this->getApi()->getContentType($apiName, $contentType, $filter, $size, $scrollId)->getResponse();
     }


### PR DESCRIPTION
Catchable Fatal Error: Argument 3 passed to
EMS\ClientHelperBundle\EMSBackendBridgeBundle\Service\ApiService::getContentType()
must be of the type array, null given, called in
elasticms\client-helper-bundle\EMSBackendBridgeBundle\Controller\ApiController.php on line 43 and defined