### PR TITLE
Improve template error messages

### DIFF
--- a/Controller/RouterController.php
+++ b/Controller/RouterController.php
@@ -65,7 +65,9 @@ class RouterController
                 $context['emsLink'] = EMSLink::fromDocument($document);
             }
 
-            return new Response($this->templating->render($template, $context), 200);
+            $content = $this->templating->render($template, $context);
+
+            return new Response($content, 200);
         } catch (SingleResultException $e) {
             throw new NotFoundHttpException();
         }

--- a/Helper/Routing/RedirectHelper.php
+++ b/Helper/Routing/RedirectHelper.php
@@ -4,6 +4,7 @@ namespace EMS\ClientHelperBundle\Helper\Routing;
 
 use EMS\ClientHelperBundle\Helper\Elasticsearch\ClientRequest;
 use EMS\ClientHelperBundle\Helper\Routing\Url\Transformer;
+use EMS\ClientHelperBundle\Helper\Twig\TwigException;
 use Symfony\Component\HttpFoundation\Request;
 
 class RedirectHelper
@@ -51,7 +52,8 @@ class RedirectHelper
             $linkTo = $document['_source']['link_to'];
 
             return $this->transformer->transform('ems://object:' . $linkTo, $locale);
-
+        } catch (TwigException $ex) {
+            throw $ex;
         } catch (\Exception $ex) {
             return false;
         }

--- a/Helper/Routing/Url/Transformer.php
+++ b/Helper/Routing/Url/Transformer.php
@@ -3,6 +3,7 @@
 namespace EMS\ClientHelperBundle\Helper\Routing\Url;
 
 use EMS\ClientHelperBundle\Helper\Elasticsearch\ClientRequest;
+use EMS\ClientHelperBundle\Helper\Twig\TwigException;
 use EMS\CommonBundle\Common\EMSLink;
 
 class Transformer
@@ -60,12 +61,14 @@ class Transformer
             if (!$emsLink->hasContentType()) {
                 return false;
             }
-            
+
             $document = $this->getDocument($emsLink);
             $template = $this->renderTemplate($emsLink, $document, $locale);
             $url = $this->generator->prependBaseUrl($emsLink, $template);
 
             return $url;
+        } catch (TwigException $ex) {
+            throw $ex;
         } catch (\Exception $ex) {
             return $ex->getMessage();
         }  

--- a/Helper/Twig/TwigException.php
+++ b/Helper/Twig/TwigException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace EMS\ClientHelperBundle\Helper\Twig;
+
+class TwigException extends \RuntimeException
+{
+
+}

--- a/Helper/Twig/TwigLoader.php
+++ b/Helper/Twig/TwigLoader.php
@@ -79,18 +79,15 @@ class TwigLoader implements \Twig_LoaderInterface
     /**
      * @param string $name
      *
-     * @return array|false
+     * @return array
      */
     private function getTemplate($name)
     {
-        if (false === $match = $this->match($name)) {
-            return false;
-        }
-
+        $match = $this->match($name);
         list($contentType, $searchValue, $searchTerm) = $match;
 
         if (!isset($this->config[$contentType])) {
-            return false;
+            throw new TwigException('Missing config EMSCH_TEMPLATES');
         }
 
         $config = $this->config[$contentType];
@@ -102,7 +99,7 @@ class TwigLoader implements \Twig_LoaderInterface
     /**
      * @param string $name
      *
-     * @return array|false
+     * @return array
      */
     private function match($name)
     {
@@ -118,7 +115,7 @@ class TwigLoader implements \Twig_LoaderInterface
             return [$matchName['content_type'], $matchName['search_val'], null];
         }
 
-        return false;
+        throw new TwigException(sprintf('Invalid template name: ', $name));
     }
 
     /**
@@ -127,7 +124,7 @@ class TwigLoader implements \Twig_LoaderInterface
      * @param string $searchTerm  _id, key, name
      * @param string $code        code field in document
      *
-     * @return array|false
+     * @return array
      */
     private function search($contentType, $searchVal, $searchTerm, $code)
     {
@@ -153,7 +150,7 @@ class TwigLoader implements \Twig_LoaderInterface
 
             return ['fresh_time' => $date->getTimestamp(), 'code' => $source[$code]];
         } catch (\Exception $e) {
-            return false;
+            throw new TwigException(sprintf('Template not found %s:%s', $contentType, $searchVal));
         }
     }
 }


### PR DESCRIPTION
If we forget defining EMSCH_TEMPLATES we just recieved an empty
response. Now when there is something wrong with a emsch template
we throw a custom Twig Exception