### PR TITLE
Add possibility for error templates

### DIFF
--- a/Controller/LanguageSelectController.php
+++ b/Controller/LanguageSelectController.php
@@ -20,32 +20,24 @@ class LanguageSelectController extends AbstractController
     private $locales;
 
     /**
-     * @var string
-     */
-    private $template;
-
-    const DEFAULT_TEMPLATE = '@EMSClientHelper/language_select.html.twig';
-
-    /**
      * @param ClientRequestManager $clientRequestManager
      * @param array                $locales
-     * @param string               $template
      */
-    public function __construct(ClientRequestManager $clientRequestManager, array $locales, $template)
+    public function __construct(ClientRequestManager $clientRequestManager, array $locales)
     {
         $this->clientRequestManager = $clientRequestManager;
         $this->locales = $locales;
-        $this->template = $template ?: self::DEFAULT_TEMPLATE;
     }
 
     /**
      * @param Request $request
+     * @param string  $template
      *
      * @return Response
      */
-    public function view(Request $request)
+    public function view(Request $request, string $template)
     {
-        return $this->render($this->template, [
+        return $this->render($template, [
             'destination' => $request->get('destination', ''),
             'locales' => $this->locales,
             'trans_default_domain' => $this->clientRequestManager->getDefault()->getCacheKey(),

--- a/Controller/SearchController.php
+++ b/Controller/SearchController.php
@@ -15,11 +15,18 @@ class SearchController extends AbstractController
     private $manager;
 
     /**
-     * @param Manager $manager
+     * @var array
      */
-    public function __construct(Manager $manager)
+    private $locales;
+
+    /**
+     * @param Manager $manager
+     * @param array   $locales
+     */
+    public function __construct(Manager $manager, array $locales)
     {
         $this->manager = $manager;
+        $this->locales = $locales;
     }
 
     /**
@@ -45,6 +52,21 @@ class SearchController extends AbstractController
             'sort' => $sortBy,
             'facets' => $facets,
             'page' => $page,
+            'language_routes' => $this->getLanguageRoutes(),
         ]);
+    }
+
+    /**
+     * @return array
+     */
+    private function getLanguageRoutes()
+    {
+        $routes = [];
+
+        foreach ($this->locales as $locale) {
+            $routes[$locale] = $this->generateUrl('emsch_search', ['_locale' => $locale]);
+        }
+
+        return $routes;
     }
 }

--- a/Controller/SearchController.php
+++ b/Controller/SearchController.php
@@ -24,10 +24,13 @@ class SearchController extends AbstractController
 
     /**
      * @param Request $request
+     * @param string  $template
+     *
      * @return Response
+     *
      * @throws \EMS\ClientHelperBundle\Exception\EnvironmentNotFoundException
      */
-    public function results(Request $request)
+    public function results(Request $request, string $template)
     {
         $clientRequest = $this->manager->getClientRequest();
         $queryString = $request->get('q', false);
@@ -35,9 +38,7 @@ class SearchController extends AbstractController
         $sortBy = $request->get('s', false);
         $page = $request->get('p', 0);
 
-
-        // @todo search template should be parameter
-        return $this->render('@EMSCH/template/services-list.html.twig', [
+        return $this->render($template, [
             'trans_default_domain' => $clientRequest->getCacheKey(),
             'results' => $this->manager->search($queryString, $facets, $request->getLocale(), $sortBy, $page),
             'query' => $queryString,

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -21,7 +21,14 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->variableNode('request_environments')->isRequired()->end()
                 ->variableNode('locales')->isRequired()->end()
-                ->scalarNode('template_language')->end()
+                ->arrayNode('templates')
+                    ->children()
+                        ->scalarNode('language')->end()
+                        ->scalarNode('search')->end()
+                        ->scalarNode('error')->end()
+                    ->end()
+                ->end()
+
             ->end()
         ;
 

--- a/EventListener/KernelListener.php
+++ b/EventListener/KernelListener.php
@@ -2,9 +2,11 @@
 
 namespace EMS\ClientHelperBundle\EventListener;
 
+use EMS\ClientHelperBundle\Helper\Request\ExceptionHelper;
 use EMS\ClientHelperBundle\Helper\Request\LocaleHelper;
 use EMS\ClientHelperBundle\Helper\Request\RequestHelper;
 use EMS\ClientHelperBundle\Helper\Translation\TranslationHelper;
+use Symfony\Component\Debug\Exception\FlattenException;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
@@ -29,19 +31,27 @@ class KernelListener implements EventSubscriberInterface
     private $localeHelper;
 
     /**
+     * @var ExceptionHelper
+     */
+    private $exceptionHelper;
+
+    /**
      * @param RequestHelper     $requestHelper
      * @param TranslationHelper $translationHelper
      * @param LocaleHelper      $localeHelper
+     * @param ExceptionHelper   $exceptionHelper
      */
     public function __construct(
         RequestHelper $requestHelper,
         TranslationHelper $translationHelper,
-        LocaleHelper $localeHelper
+        LocaleHelper $localeHelper,
+        ExceptionHelper $exceptionHelper
     )
     {
         $this->requestHelper = $requestHelper;
         $this->translationHelper = $translationHelper;
         $this->localeHelper = $localeHelper;
+        $this->exceptionHelper = $exceptionHelper;
     }
 
     /**
@@ -58,7 +68,8 @@ class KernelListener implements EventSubscriberInterface
             KernelEvents::EXCEPTION => [
                 ['bindEnvironment', 100],
                 ['redirectMissingLocale', 21],
-                ['loadTranslations', 20] //not found is maybe redirected or custom error pages with translations
+                ['loadTranslations', 20], //not found is maybe redirected or custom error pages with translations
+                ['customErrorTemplate', -10],
             ]
         ];
     }
@@ -111,6 +122,18 @@ class KernelListener implements EventSubscriberInterface
 
         if (false === $this->localeHelper->getLocale($request)) {
             $event->setResponse($this->localeHelper->redirectMissingLocale($request));
+        }
+    }
+
+    /**
+     * @param GetResponseForExceptionEvent $event
+     */
+    public function customErrorTemplate(GetResponseForExceptionEvent $event)
+    {
+        $flattenException = FlattenException::create($event->getException());
+
+        if ($template = $this->exceptionHelper->renderError($flattenException)) {
+            $event->setResponse($template);
         }
     }
 }

--- a/Helper/Request/ExceptionHelper.php
+++ b/Helper/Request/ExceptionHelper.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace EMS\ClientHelperBundle\Helper\Request;
+
+use EMS\ClientHelperBundle\Helper\Twig\TwigException;
+use Symfony\Component\Debug\Exception\FlattenException;
+use Symfony\Component\HttpFoundation\Response;
+
+class ExceptionHelper
+{
+    /**
+     * @var \Twig\Environment
+     */
+    private $twig;
+
+    /**
+     * @var string
+     */
+    private $template;
+
+    /**
+     * @var bool
+     */
+    private $debug;
+
+    /**
+     * @param \Twig\Environment $twig
+     * @param bool              $debug
+     * @param string            $template
+     */
+    public function __construct(\Twig\Environment $twig, bool $debug, string $template = null)
+    {
+        $this->twig = $twig;
+        $this->debug = $debug;
+        $this->template = $template;
+    }
+
+    /**
+     * @param FlattenException $exception
+     *
+     * @return Response|false
+     */
+    public function renderError(FlattenException $exception)
+    {
+        if (null === $this->template || $this->debug) {
+            return false;
+        }
+
+        $code = $exception->getStatusCode();
+        $template = $this->getTemplate($code);
+
+        return new Response($this->twig->render($template, [
+            'trans_default_domain' => 'catalog_template',
+            'emsLink' => 'test',
+            'status_code' => $code,
+            'status_text' => isset(Response::$statusTexts[$code]) ? Response::$statusTexts[$code] : '',
+            'exception' => $exception,
+        ]));
+    }
+
+    /**
+     * @param string $code
+     *
+     * @return string
+     */
+    private function getTemplate(string $code)
+    {
+        $customCodeTemplate = str_replace('{code}', $code, $this->template);
+
+        if ($this->templateExists($customCodeTemplate)) {
+            return $customCodeTemplate;
+        }
+
+        $errorTemplate = str_replace('{code}', '', $this->template);
+
+        if ($this->templateExists($errorTemplate)) {
+            return $errorTemplate;
+        }
+
+        throw new TwigException(sprintf('template "%s" does not exists', $errorTemplate));
+    }
+
+    /**
+     * @param string $template
+     *
+     * @return bool
+     */
+    protected function templateExists(string $template)
+    {
+        try {
+            $loader = $this->twig->getLoader();
+            $loader->getSourceContext($template)->getCode();
+
+            return true;
+        } catch (\Exception $e) {
+            return false;
+        }
+    }
+}

--- a/Helper/Routing/BaseRouter.php
+++ b/Helper/Routing/BaseRouter.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace EMS\ClientHelperBundle\Helper\Routing;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Generator\UrlGenerator;
+use Symfony\Component\Routing\Matcher\UrlMatcher;
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Routing\Matcher\RequestMatcherInterface;
+
+abstract class BaseRouter implements RouterInterface, RequestMatcherInterface
+{
+    /**
+     * @var RequestContext
+     */
+    protected $context;
+
+    /**
+     * @var RouteCollection
+     */
+    protected $collection;
+
+    /**
+     * @var UrlMatcher
+     */
+    protected $matcher;
+
+    /**
+     * @var UrlGenerator
+     */
+    protected $generator;
+
+    /**
+     * @inheritdoc
+     */
+    public function getContext()
+    {
+        return $this->context;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setContext(RequestContext $context)
+    {
+        $this->context = $context;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getRouteCollection()
+    {
+        return $this->collection;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function match($pathinfo)
+    {
+        return $this->getMatcher()->match($pathinfo);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function matchRequest(Request $request)
+    {
+        return $this->getMatcher()->matchRequest($request);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function generate($name, $parameters = [], $referenceType = self::ABSOLUTE_PATH)
+    {
+        return $this->getGenerator()->generate($name, $parameters, $referenceType);
+    }
+
+    /**
+     * @return UrlMatcher
+     */
+    private function getMatcher(): UrlMatcher
+    {
+        if (null === $this->matcher) {
+            $this->matcher = new UrlMatcher($this->getRouteCollection(), $this->getContext());
+        }
+
+        return $this->matcher;
+    }
+
+    /**
+     * @return UrlGenerator
+     */
+    private function getGenerator(): UrlGenerator
+    {
+        if (null === $this->generator) {
+            $this->generator = new UrlGenerator($this->getRouteCollection(), $this->getContext());
+        }
+
+        return $this->generator;
+    }
+}

--- a/Helper/Routing/EMSRouter.php
+++ b/Helper/Routing/EMSRouter.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace EMS\ClientHelperBundle\Helper\Routing;
+
+use Symfony\Component\Routing\RouteCollection;
+
+class EMSRouter extends BaseRouter
+{
+    /**
+     * @var array
+     */
+    private $routes;
+
+    /**
+     * @param array $routes
+     */
+    public function __construct(array $routes)
+    {
+        $this->routes = $routes;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getRouteCollection()
+    {
+        if (null === $this->collection) {
+            $this->collection = $this->buildCollection();
+        }
+
+        return $this->collection;
+    }
+
+    /**
+     * @return RouteCollection
+     */
+    private function buildCollection(): RouteCollection
+    {
+        $configs = array_map(function (string $name, array $options) {
+            return new RouteConfig($name, $options, true);
+        }, array_keys($this->routes), $this->routes);
+
+        $collection = new RouteCollection();
+
+        foreach ($configs as $config) {
+            /* @var $config RouteConfig */
+            $collection->add($config->getName(), $config->getRoute());
+        }
+
+        return $collection;
+    }
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -65,6 +65,7 @@
         </service>
         <service id="emsch.controller.search" class="EMS\ClientHelperBundle\Controller\SearchController" public="true">
             <argument type="service" id="emsch.search.manager" />
+            <argument type="string">%emsch.locales%</argument>
         </service>
         <service id="emsch.controller.twig_list" class="EMS\ClientHelperBundle\Controller\TwigListController" public="true">
             <argument type="service" id="kernel" />

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -21,10 +21,21 @@
             <argument type="service" id="router"/>
             <argument type="string">%emsch.locales%</argument>
         </service>
+        <service id="emsch.helper_exception" class="EMS\ClientHelperBundle\Helper\Request\ExceptionHelper">
+            <argument type="service" id="twig" />
+            <argument>%kernel.debug%</argument>
+            <argument></argument>
+        </service>
         <service id="emsch.helper_translation" class="EMS\ClientHelperBundle\Helper\Translation\TranslationHelper">
             <argument type="service" id="emsch.manager.client_request" />
             <argument type="service" id="translator.default" />
             <argument type="service" id="cache.app" />
+        </service>
+
+        <service id="emsch.router" class="EMS\ClientHelperBundle\Helper\Routing\Router">
+            <argument type="string">%emsch.locales%</argument>
+            <argument></argument>
+            <tag name="emsch.router" />
         </service>
 
         <!-- event listeners -->
@@ -32,7 +43,7 @@
             <argument type="service" id="emsch.helper_request"/>
             <argument type="service" id="emsch.helper_translation" />
             <argument type="service" id="emsch.helper_locale" />
-
+            <argument type="service" id="emsch.helper_exception" />
             <tag name="kernel.event_subscriber" />
         </service>
 
@@ -50,7 +61,7 @@
         <service id="emsch.controller.language_select" class="EMS\ClientHelperBundle\Controller\LanguageSelectController" public="true">
             <argument type="service" id="emsch.manager.client_request" />
             <argument type="string">%emsch.locales%</argument>
-            <argument type="string">%emsch.template_language%</argument>
+            <argument></argument>
         </service>
         <service id="emsch.controller.search" class="EMS\ClientHelperBundle\Controller\SearchController" public="true">
             <argument type="service" id="emsch.search.manager" />


### PR DESCRIPTION
Added new Router for config/env routes -> search & language_select.
Otherwise these routers would be generated for each elasticms config.

New config reference:

ems_client_helper:
	templates:
		language: '%env(string:EMSCH_TEMPLATE_LANGUAGE)%'
		search:   '%env(string:EMSCH_TEMPLATE_SEARCH)%'
		error:    '%env(string:EMSCH_TEMPLATE_ERROR)%'