### PR TITLE
Improve request helper

### DIFF
--- a/Helper/Request/Environment.php
+++ b/Helper/Request/Environment.php
@@ -36,7 +36,7 @@ class Environment
         $this->name = $name;
 
         $this->regex = $config['regex'] ?? '*';
-        $this->backend = $config['backend'] ?? null;
+        $this->backend = $config['backend'] ?? false;
         $this->index = $config['index'] ?? null;
         $this->request = $config['request'] ?? [];
     }
@@ -50,7 +50,7 @@ class Environment
             return $this->index;
         }
 
-        return $this->request['_environment'] ? $this->name : null;
+        return $this->request['_environment'] ? $this->request['_environment'] : $this->name;
     }
 
     public function matchRequest(Request $request)
@@ -66,13 +66,14 @@ class Environment
 
     public function modifyRequest(Request $request)
     {
+        // backward compatibility
+        $request->attributes->set('_environment', $this->getIndex());
+        $request->attributes->set('_backend', $this->backend);
+
         if (!empty($this->request)) {
             foreach ($this->request as $key => $value) {
                 $request->attributes->set($key, $value);
             }
-        } else {
-            $request->attributes->set('_environment', $this->getIndex());
-            $request->attributes->set('_backend', $this->backend);
         }
     }
 }

--- a/Helper/Request/RequestHelper.php
+++ b/Helper/Request/RequestHelper.php
@@ -50,17 +50,10 @@ class RequestHelper
         }
 
         foreach ($this->environments as $env) {
-            if (!$env->match($request)) {
-                continue;
+            if ($env->matchRequest($request)) {
+                $env->modifyRequest($request);
+                break;
             }
-
-            $request->attributes->set('_environment', $env->getIndex());
-
-            if(!empty($env->getBackend())) {
-                $request->attributes->set('_backend', $env->getBackend());
-            }
-
-            return; //stop on match
         }
     }
 
@@ -91,7 +84,7 @@ class RequestHelper
 
         return $env;
     }
-    
+
     /**
      * @return string
      */


### PR DESCRIPTION
Implement the possibility to force the _locale based on the regex match.
Make it future prove so we can assign attributes dynamically.

Before:
EMSCH_ENVS='{"template": {"regex": "/.*/", "index": "template"}}'

After:
EMSCH_ENVS='{"template": {"regex": "/.*/", "request": {"_environment": "template", "_locale": "nl"} }}'