### PR TITLE
bugfix: filtering %locale%

### DIFF
--- a/Helper/Search/Filter.php
+++ b/Helper/Search/Filter.php
@@ -124,13 +124,14 @@ class Filter
 
     public function handleRequest(Request $request): void
     {
-        $value = $request->get($this->name);
+        $this->field = str_replace('%locale%', $request->getLocale(), $this->field);
+        $requestValue = $request->get($this->name);
 
-        if (!$this->public || null == $value) {
-            return;
+        if ($this->value !== null ) {
+            $this->setQuery($this->value);
+        } elseif ($this->public && $requestValue) {
+            $this->setQuery($requestValue);
         }
-
-        $this->setQuery($value);
     }
 
     public function handleAggregation(array $aggregation)
@@ -162,29 +163,20 @@ class Filter
 
     private function setQuery($value): void
     {
-        if (self::TYPE_TERM == $this->type && !\is_string($value)) {
-            return;
-        }
-
         switch ($this->type) {
             case self::TYPE_TERM:
                 $this->value = $value;
-                $this->query = $this->getQueryTerms([$this->value]);
+                $this->query = ['term' => [$this->field => ['value' => $value]]];
                 break;
             case self::TYPE_TERMS:
                 $this->value = \is_array($value) ? $value : [$value];
-                $this->query = $this->getQueryTerms($this->value);
+                $this->query = ['terms' => [$this->field => $value]];
                 break;
             case self::TYPE_DATE_RANGE:
                 $this->value = \is_array($value) ? $value : [$value];
                 $this->query = $this->getQueryDateRange($this->value);
                 break;
         }
-    }
-
-    private function getQueryTerms(array $value): array
-    {
-        return ['terms' => [$this->field => $value]];
     }
 
     private function getQueryDateRange(array $value): ?array

--- a/Helper/Search/Filter.php
+++ b/Helper/Search/Filter.php
@@ -127,7 +127,7 @@ class Filter
         $this->field = str_replace('%locale%', $request->getLocale(), $this->field);
         $requestValue = $request->get($this->name);
 
-        if ($this->value !== null ) {
+        if ($this->value !== null) {
             $this->setQuery($this->value);
         } elseif ($this->public && $requestValue) {
             $this->setQuery($requestValue);

--- a/Helper/Search/QueryBuilder.php
+++ b/Helper/Search/QueryBuilder.php
@@ -134,7 +134,6 @@ class QueryBuilder
             $this->search->getSortBy() => [
                 'order' => $this->search->getSortOrder(),
                 'missing' => '_last',
-                'unmapped_type' => 'long'
             ]
         ];
     }


### PR DESCRIPTION
- improve term search
- filter fields with %locale% should be replaced by the request locale

filter: {
 	"show": {
 		"type": "term",
		"field": "show_%locale%",
 		"value": true,
		"optional": true,
		"public": false
	}
}