### PR TITLE
Improve search date range now

### DIFF
--- a/Helper/Search/Filter.php
+++ b/Helper/Search/Filter.php
@@ -186,25 +186,22 @@ class Filter
         }
 
         $format = 'd-m-Y H:i:s';
-        $start = $end = false;
+        $start = $end = null;
 
         if (isset($value['start'])) {
-            $start = \DateTime::createFromFormat($format, $value['start'].' 00:00:00');
+            $startDatetime = \DateTime::createFromFormat($format, $value['start'].' 00:00:00');
+            $start = $startDatetime ? $startDatetime->format('Y-m-d') : $value['start'];
         }
         if (isset($value['end'])) {
-            $end = \DateTime::createFromFormat($format, $value['end'].' 23:59:59');
+            $endDatetime = \DateTime::createFromFormat($format, $value['end'].' 23:59:59');
+            $end = $endDatetime ? $endDatetime->format('Y-m-d') : $value['end'];
         }
 
         if (!$start && !$end) {
             return null;
         }
 
-        return ['range' => [
-            $this->field => array_filter([
-                'gte' => $start !== false ? $start->format('Y-m-d') : null,
-                'lte' => $end !== false ? $end->format('Y-m-d') : null,
-            ])
-        ]];
+        return ['range' => [ $this->field => array_filter(['gte' => $start, 'lte' => $end,]) ]];
     }
 
     private function getQueryOptional(): array

--- a/Helper/Search/Filter.php
+++ b/Helper/Search/Filter.php
@@ -197,7 +197,7 @@ class Filter
             $end = $endDatetime ? $endDatetime->format('Y-m-d') : $value['end'];
         }
 
-        if (!$start && !$end) {
+        if ($start === null && $end === null) {
             return null;
         }
 


### PR DESCRIPTION
They values provided to the date range are always converted to datetime
objects. But now we want to only search on documents that have a
datetime field in the past.