### PR TITLE
Fix post filtering aggregations

### DIFF
--- a/Helper/Search/Filter.php
+++ b/Helper/Search/Filter.php
@@ -156,10 +156,10 @@ class Filter
     {
         $this->setChoices();
 
-        foreach ($aggregation['buckets'] as $bucket) {
-            if (isset($this->choices[$bucket['key']])) {
-                $this->choices[$bucket['key']]['filter'] = $bucket['doc_count'];
-            }
+        if (isset($aggregation['buckets'])) {
+            $this->handleBuckets($aggregation['buckets']);
+        } elseif (isset($aggregation['filtered_'.$this->name]['buckets'])) {
+            $this->handleBuckets($aggregation['filtered_'.$this->name]['buckets']);
         }
     }
 
@@ -275,6 +275,15 @@ class Filter
             $this->postFilter = true; //default post filtering for public terms filters
         } else {
             $this->postFilter = false;
+        }
+    }
+
+    private function handleBuckets(array $buckets)
+    {
+        foreach ($buckets as $bucket) {
+            if (isset($this->choices[$bucket['key']])) {
+                $this->choices[$bucket['key']]['filter'] = $bucket['doc_count'];
+            }
         }
     }
 }

--- a/Helper/Search/Manager.php
+++ b/Helper/Search/Manager.php
@@ -54,8 +54,9 @@ class Manager
 
         foreach ($aggregations as $type => $data) {
             $counters[$type] = [];
+            $buckets = $data['buckets'] ?? [];
 
-            foreach ($data['buckets'] as $bucket) {
+            foreach ($buckets as $bucket) {
                 $counters[$type][$bucket['key']] = $bucket['doc_count'];
             }
         }


### PR DESCRIPTION
When we use post filters we should also filter the aggregations.
This way the counts are always correct.

https://www.elastic.co/guide/en/elasticsearch/reference/5.4/search-request-post-filter.html