### PR TITLE
bugfix: undefined translation catalogue

### DIFF
--- a/Helper/Translation/TranslationHelper.php
+++ b/Helper/Translation/TranslationHelper.php
@@ -38,6 +38,10 @@ class TranslationHelper
             $messages = $this->getMessages($clientRequest);
 
             foreach ($this->locales as $locale) {
+                if (!isset($messages[$locale])) {
+                    continue;
+                }
+
                 $clientCatalog = new MessageCatalogue($locale);
                 $clientCatalog->add($messages[$locale], $clientRequest->getCacheKey());
 


### PR DESCRIPTION
When no translations keys are defined for a emsch_locale we get
ErrorException.