### PR TITLE
urgent bugfix: use main query in aggregations

### DIFF
--- a/Helper/Search/Filter.php
+++ b/Helper/Search/Filter.php
@@ -33,6 +33,10 @@ class Filter
     private $public;
     /** @var bool if not all doc contain the filter */
     private $optional;
+    /** @var array */
+    private $queryFilters = [];
+    /** @var array */
+    private $queryTypes = [];
 
     /** @var array */
     private $query = [];
@@ -159,8 +163,10 @@ class Filter
         }
     }
 
-    public function handleAggregation(array $aggregation)
+    public function handleAggregation(array $aggregation, array $types = [], array $queryFilters = [])
     {
+        $this->queryTypes = $types;
+        $this->queryFilters = $queryFilters;
         $this->setChoices();
 
         $data = $aggregation['nested'] ?? $aggregation;
@@ -287,7 +293,7 @@ class Filter
             ];
         }
 
-        $search = $this->clientRequest->searchArgs(['body' => ['size' => 0, 'aggs' => [$this->name => $aggs]] ]);
+        $search = $this->clientRequest->searchArgs(['type' => $this->queryTypes, 'body' => ['query' => $this->queryFilters, 'size' => 0, 'aggs' => [$this->name => $aggs]]]);
 
         $result = $search['aggregations'][$this->name];
         $buckets = $this->isNested() ? $result['nested']['buckets'] : $result['buckets'];

--- a/Helper/Search/Manager.php
+++ b/Helper/Search/Manager.php
@@ -32,7 +32,7 @@ class Manager
         $results = $this->clientRequest->search($search->getTypes(), $body, $search->getFrom(), $search->getSize());
 
         if (isset($results['aggregations'])) {
-            $search->bindAggregations($results['aggregations']);
+            $search->bindAggregations($results['aggregations'], $qbService->getQueryFilters());
         }
 
         return [

--- a/Helper/Search/QueryBuilder.php
+++ b/Helper/Search/QueryBuilder.php
@@ -67,7 +67,7 @@ class QueryBuilder
         return $query;
     }
 
-    private function getQueryFilters(): array
+    public function getQueryFilters(): array
     {
         $query = [];
         $nestedQueries = [];

--- a/Helper/Search/Search.php
+++ b/Helper/Search/Search.php
@@ -87,11 +87,11 @@ class Search
         }
     }
 
-    public function bindAggregations(array $aggregations): void
+    public function bindAggregations(array $aggregations, array $queryFilters): void
     {
         foreach ($aggregations as $name => $aggregation) {
             if ($this->hasFilter($name)) {
-                $this->getFilter($name)->handleAggregation($aggregation);
+                $this->getFilter($name)->handleAggregation($aggregation, $this->getTypes(), $queryFilters);
             }
         }
     }


### PR DESCRIPTION
TODO: review the FILTER concept and use the 'non public' as default on
filters in the search class. QueryBuilder concepts should receive better
names, and the default filters should be accessible more easily (through
the SEARCH object)