### PR TITLE
hot(build query): misformatted date

### DIFF
--- a/Helper/Search/Filter.php
+++ b/Helper/Search/Filter.php
@@ -246,11 +246,11 @@ class Filter
 
         if (!empty($value['start'])) {
             $startDatetime = \DateTime::createFromFormat($format, $value['start'] . ' 00:00:00');
-            $start = $startDatetime ? $startDatetime->format('Y-m-d') : $value['start'];
+            $start = $startDatetime ? $startDatetime->format('Y-m-d') : null;
         }
         if (!empty($value['end'])) {
             $endDatetime = \DateTime::createFromFormat($format, $value['end'] . ' 23:59:59');
-            $end = $endDatetime ? $endDatetime->format('Y-m-d') : $value['end'];
+            $end = $endDatetime ? $endDatetime->format('Y-m-d') : null;
         }
 
         if ($start === null && $end === null) {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -31,7 +31,7 @@ parameters:
 			path: Command/HealthCheckCommand.php
 
 		-
-			message: "#^Method EMS\\\\ClientHelperBundle\\\\Command\\\\HealthCheckCommand\\:\\:execute\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method EMS\\\\ClientHelperBundle\\\\Command\\\\HealthCheckCommand\\:\\:execute\\(\\) should return int but return statement is missing\\.$#"
 			count: 1
 			path: Command/HealthCheckCommand.php
 


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |Y|
|New feature?   |N|	
|BC breaks?     |N|	
|Deprecations?  |N|	
|Fixed tickets  |N|	

Fix that a misformatted date generate a wrong elasticsearch query 