### PR TITLE
hot(routing): allow a route's query to have more than one in total

### DIFF
--- a/Helper/Elasticsearch/ClientRequest.php
+++ b/Helper/Elasticsearch/ClientRequest.php
@@ -639,12 +639,12 @@ class ClientRequest
     public function searchOne($type, array $body, ?string $indexRegex = null)
     {
         $this->logger->debug('ClientRequest : searchOne for {type}', ['type' => $type, 'body' => $body, 'indexRegex' => $indexRegex]);
-        $search = $this->search($type, $body, 0, 1, [], $indexRegex);
+        $search = $this->search($type, $body, 0, 2, [], $indexRegex);
 
         $hits = $search['hits'];
 
-        if (1 != $hits['total']) {
-            throw new SingleResultException(sprintf('expected 1 result, got %d', $hits['total']));
+        if (1 !== count($hits['hits'])) {
+            throw new SingleResultException(sprintf('expected 1 result, got %d', $hits['hits']));
         }
 
         return $hits['hits'][0];

--- a/Helper/Elasticsearch/ClientRequest.php
+++ b/Helper/Elasticsearch/ClientRequest.php
@@ -643,7 +643,7 @@ class ClientRequest
 
         $hits = $search['hits'];
 
-        if (1 !== count($hits['hits'])) {
+        if (1 !== \count($hits['hits'])) {
             throw new SingleResultException(sprintf('expected 1 result, got %d', $hits['hits']));
         }
 


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |Y|
|New feature?   |Y|	
|BC breaks?     |N|	
|Deprecations?  |N|	
|Fixed tickets  |N|	

By defining the size in the query we may accept multiple results in route's query