### PR TITLE
feat: api client form verification

### DIFF
--- a/DependencyInjection/EMSClientHelperExtension.php
+++ b/DependencyInjection/EMSClientHelperExtension.php
@@ -83,6 +83,7 @@ class EMSClientHelperExtension extends Extension
             $definition->setArgument(0, $name);
             $definition->setArgument(1, $options['url']);
             $definition->setArgument(2, $options['key']);
+            $definition->setArgument(3, new Reference('logger'));
             $definition->addTag('emsch.api_client');
 
             $container->setDefinition(sprintf('emsch.api_client.%s', $name), $definition);

--- a/Helper/Api/ApiService.php
+++ b/Helper/Api/ApiService.php
@@ -266,7 +266,7 @@ class ApiService
         throw new NotFoundHttpException();
     }
 
-    private function getApiClient(string $clientName): Client
+    public function getApiClient(string $clientName): Client
     {
         foreach ($this->apiClients as $apiClient) {
             if ($clientName === $apiClient->getName()) {

--- a/Helper/Api/Client.php
+++ b/Helper/Api/Client.php
@@ -150,7 +150,7 @@ class Client
         return \json_decode($response->getBody()->getContents(), true);
     }
 
-    public function createFormVerification(string $value): ?int
+    public function createFormVerification(string $value): ?string
     {
         try {
             $response = $this->client->post('/api/forms/verifications', [
@@ -159,14 +159,14 @@ class Client
 
             $json = \json_decode($response->getBody()->getContents(), true);
 
-            return isset($json['code']) ? (int) $json['code'] : null;
+            return isset($json['code']) ? $json['code'] : null;
         } catch (RequestException $e) {
             $this->logger->error($e->getMessage());
             return null;
         }
     }
 
-    public function getFormVerification(string $value): ?int
+    public function getFormVerification(string $value): ?string
     {
         try {
             $response = $this->client->get('/api/forms/verifications', [
@@ -175,7 +175,7 @@ class Client
 
             $json = \json_decode($response->getBody()->getContents(), true);
 
-            return isset($json['code']) ? (int) $json['code'] : null;
+            return isset($json['code']) ? $json['code'] : null;
         } catch (RequestException $e) {
             $this->logger->error($e->getMessage());
             return null;

--- a/Helper/Api/Client.php
+++ b/Helper/Api/Client.php
@@ -4,7 +4,6 @@ namespace EMS\ClientHelperBundle\Helper\Api;
 
 use EMS\CommonBundle\Common\HttpClientFactory;
 use GuzzleHttp\Client as HttpClient;
-use GuzzleHttp\Exception\RequestException;
 use Psr\Log\LoggerInterface;
 
 class Client
@@ -160,7 +159,7 @@ class Client
             $json = \json_decode($response->getBody()->getContents(), true);
 
             return isset($json['code']) ? $json['code'] : null;
-        } catch (RequestException $e) {
+        } catch (\Exception $e) {
             $this->logger->error($e->getMessage());
             return null;
         }
@@ -176,7 +175,7 @@ class Client
             $json = \json_decode($response->getBody()->getContents(), true);
 
             return isset($json['code']) ? $json['code'] : null;
-        } catch (RequestException $e) {
+        } catch (\Exception $e) {
             $this->logger->error($e->getMessage());
             return null;
         }


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |no|
|New feature?   |yes|	
|BC breaks?     |no|	
|Deprecations?  |no|	
|Fixed tickets  |no|	

Add 2 methods to the elasticms backend api client
- createFormVerification
- getFormVerification

Make getApiClient public on the ApiService:
The formBundle was not able to get the ApiClient.

Inject the Logger in the ApiService, for logging errors. In the future we should remove the Guzzle HttpClient and use the Symfony HttpClient