### PR TITLE
release: 3.3.2

### DIFF
--- a/DependencyInjection/EMSClientHelperExtension.php
+++ b/DependencyInjection/EMSClientHelperExtension.php
@@ -83,6 +83,7 @@ class EMSClientHelperExtension extends Extension
             $definition->setArgument(0, $name);
             $definition->setArgument(1, $options['url']);
             $definition->setArgument(2, $options['key']);
+            $definition->setArgument(3, new Reference('logger'));
             $definition->addTag('emsch.api_client');
 
             $container->setDefinition(sprintf('emsch.api_client.%s', $name), $definition);

--- a/Helper/Api/ApiService.php
+++ b/Helper/Api/ApiService.php
@@ -266,7 +266,7 @@ class ApiService
         throw new NotFoundHttpException();
     }
 
-    private function getApiClient(string $clientName): Client
+    public function getApiClient(string $clientName): Client
     {
         foreach ($this->apiClients as $apiClient) {
             if ($clientName === $apiClient->getName()) {

--- a/Helper/Api/Client.php
+++ b/Helper/Api/Client.php
@@ -4,6 +4,7 @@ namespace EMS\ClientHelperBundle\Helper\Api;
 
 use EMS\CommonBundle\Common\HttpClientFactory;
 use GuzzleHttp\Client as HttpClient;
+use Psr\Log\LoggerInterface;
 
 class Client
 {
@@ -22,16 +23,20 @@ class Client
      */
     private $name;
 
+    /** @var LoggerInterface */
+    private $logger;
+
     /**
      * @param string $name
      * @param string $baseUrl
      * @param string $key
      */
-    public function __construct($name, $baseUrl, $key)
+    public function __construct($name, $baseUrl, $key, LoggerInterface $logger)
     {
         $this->name = $name;
         $this->key = $key;
         $this->client = HttpClientFactory::create($baseUrl, ['X-Auth-Token' => $this->key]);
+        $this->logger = $logger;
     }
 
     public function getName()
@@ -142,5 +147,37 @@ class Client
         ]);
 
         return \json_decode($response->getBody()->getContents(), true);
+    }
+
+    public function createFormVerification(string $value): ?string
+    {
+        try {
+            $response = $this->client->post('/api/forms/verifications', [
+                'json' => ['value' => $value],
+            ]);
+
+            $json = \json_decode($response->getBody()->getContents(), true);
+
+            return isset($json['code']) ? $json['code'] : null;
+        } catch (\Exception $e) {
+            $this->logger->error($e->getMessage());
+            return null;
+        }
+    }
+
+    public function getFormVerification(string $value): ?string
+    {
+        try {
+            $response = $this->client->get('/api/forms/verifications', [
+                'query' => ['value' => $value],
+            ]);
+
+            $json = \json_decode($response->getBody()->getContents(), true);
+
+            return isset($json['code']) ? $json['code'] : null;
+        } catch (\Exception $e) {
+            $this->logger->error($e->getMessage());
+            return null;
+        }
     }
 }


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |no|
|New feature?   |yes|	
|BC breaks?     |no|	
|Deprecations?  |no|	
|Fixed tickets  |no|	

Add 2 methods to the elasticms backend api client
- createFormVerification
- getFormVerification

Make getApiClient public on the ApiService:
The formBundle was not able to get the ApiClient.