### PR TITLE
fix: search filter disable date format

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -781,11 +781,6 @@ parameters:
 			path: Helper/Environment/Environment.php
 
 		-
-			message: "#^Parameter \\#1 \\$key of method Symfony\\\\Component\\\\HttpFoundation\\\\ParameterBag\\:\\:set\\(\\) expects string, int\\|string given\\.$#"
-			count: 1
-			path: Helper/Environment/Environment.php
-
-		-
 			message: "#^Method EMS\\\\ClientHelperBundle\\\\Helper\\\\Environment\\\\EnvironmentHelper\\:\\:__construct\\(\\) has parameter \\$environments with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: Helper/Environment/EnvironmentHelper.php


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |yes|
|New feature?   |no|	
|BC breaks?     |no|	
|Deprecations?  |no|	
|Fixed tickets  |no|	

We need to be able just passing 'now' as filter value, but for that we need to disable the date input formatting. 
You can now set the date_format of a filter config to false.