### PR TITLE
fix: clientRequest scroll index

### DIFF
--- a/Helper/Elasticsearch/ClientRequest.php
+++ b/Helper/Elasticsearch/ClientRequest.php
@@ -615,6 +615,7 @@ class ClientRequest
      */
     public function scrollAll(array $params, $timeout = '30s'): iterable
     {
+        $params['index'] = $this->getIndex();
         $search = $this->elasticaService->convertElasticsearchSearch($params);
         $scroll = $this->elasticaService->scroll($search, $timeout);
 


### PR DESCRIPTION


|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

ScrollAll should use the clientRequest index.
Otherwise building all routes and translations in the cluster