### PR TITLE
refactor: access (set/get) to cache items

### DIFF
--- a/src/Helper/ContentType/ContentType.php
+++ b/src/Helper/ContentType/ContentType.php
@@ -54,6 +54,29 @@ final class ContentType
     }
 
     /**
+     * @return mixed|null
+     */
+    public function getCacheItem(string $itemId)
+    {
+        if (null !== $this->cache && isset($this->cache[$itemId])) {
+            return $this->cache[$itemId];
+        }
+
+        return null;
+    }
+
+    /**
+     * @param mixed $cacheable
+     */
+    public function setCacheItem(string $itemId, $cacheable): void
+    {
+        if (null === $this->cache) {
+            $this->cache = [];
+        }
+        $this->cache[$itemId] = $cacheable;
+    }
+
+    /**
      * @param ?array<mixed> $cache
      */
     public function setCache(?array $cache): void


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |N|
|New feature?   |Y|	
|BC breaks?     |N|	
|Deprecations?  |N|	
|Fixed tickets  |N|	

In some cases we want to cache one content type's document i.e. when it's about to cache a form response in the form bundle