### PR TITLE
fix: remove EMS\CommonBundle\Logger\ElasticsearchLogger

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -19,18 +19,6 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
-                ->arrayNode('log')
-                    ->children()
-                        ->scalarNode('instance_id')->end()
-                        ->booleanNode('by_pass')
-                            ->defaultFalse()
-                        ->end()
-                        ->variableNode('hosts')
-                            ->info('elasticsearch hosts')
-                            ->isRequired()
-                        ->end()
-                    ->end()
-                ->end()
                 ->variableNode('request_environments')->isRequired()->end()
                 ->variableNode('locales')->isRequired()->end()
                 ->booleanNode('bind_locale')->end()

--- a/src/DependencyInjection/EMSClientHelperExtension.php
+++ b/src/DependencyInjection/EMSClientHelperExtension.php
@@ -5,7 +5,6 @@ namespace EMS\ClientHelperBundle\DependencyInjection;
 use EMS\ClientHelperBundle\Helper\Api\Client as ApiClient;
 use EMS\ClientHelperBundle\Helper\Elasticsearch\ClientRequest;
 use EMS\ClientHelperBundle\Helper\Twig\TwigLoader;
-use EMS\CommonBundle\Logger\ElasticsearchLogger;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -39,8 +38,6 @@ class EMSClientHelperExtension extends Extension
         $container->setParameter('emsch.templates', $config['templates']);
         $container->getDefinition('emsch.helper_exception')->replaceArgument(3, $templates['error']);
         $container->getDefinition('emsch.routing.url.transformer')->replaceArgument(4, $templates['ems_link']);
-
-        $this->defineElasticsearchLogger($container, $config['log']);
 
         $this->processElasticms($container, $loader, $config['elasticms']);
         $this->processApi($container, $config['api']);
@@ -76,27 +73,6 @@ class EMSClientHelperExtension extends Extension
 
             $container->setDefinition(\sprintf('emsch.api_client.%s', $name), $definition);
         }
-    }
-
-    private function defineElasticsearchLogger(ContainerBuilder $container, array $options)
-    {
-        $definition = new Definition(ElasticsearchLogger::class);
-        $definition->setArguments([
-            'info',
-            $options['instance_id'],
-            '',
-            'ems_client',
-            new Reference('ems_common.elastica.client'),
-            new Reference('security.helper'),
-            new Reference('ems_common.service.mapping'),
-            $options['by_pass'],
-        ]);
-        $definition->addTag('kernel.cache_warmer');
-        $definition->addTag('kernel.event_listener', [
-            'event' => 'kernel.terminate',
-        ]);
-
-        $container->setDefinition('ems_common.elasticsearch.logger', $definition);
     }
 
     /**


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |y|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

The clientHelper does not need the ElasticsearchLogger any more