### PR TITLE
release 3.6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,6 +64,6 @@
 	},
 	"scripts": {
 		"phpcs": "php-cs-fixer fix",
-		"phpstan": "phpstan analyse ."
+		"phpstan": "phpstan analyse"
 	}
 }

--- a/src/Helper/ContentType/ContentTypeHelper.php
+++ b/src/Helper/ContentType/ContentTypeHelper.php
@@ -43,6 +43,18 @@ final class ContentTypeHelper
 
     private function makeContentTypeCollection(ClientRequest $clientRequest, Environment $environment): ContentTypeCollection
     {
+        try {
+            $search = $this->createContentTypeSearch($environment);
+            $response = Response::fromResultSet($clientRequest->commonSearch($search));
+
+            return ContentTypeCollection::fromResponse($environment->getName(), $response);
+        } catch (\Exception $e) {
+            return new ContentTypeCollection();
+        }
+    }
+
+    private function createContentTypeSearch(Environment $environment): Search
+    {
         $maxUpdate = new Max(self::AGG_LAST_PUBLISHED);
         $maxUpdate->setField('_published_datetime');
 
@@ -55,8 +67,6 @@ final class ContentTypeHelper
         $search->setSize(0);
         $search->addAggregation($lastUpdate);
 
-        $response = Response::fromResultSet($clientRequest->commonSearch($search));
-
-        return ContentTypeCollection::fromResponse($environment->getName(), $response);
+        return $search;
     }
 }

--- a/src/Helper/Search/Manager.php
+++ b/src/Helper/Search/Manager.php
@@ -4,6 +4,7 @@ namespace EMS\ClientHelperBundle\Helper\Search;
 
 use EMS\ClientHelperBundle\Helper\Elasticsearch\ClientRequest;
 use EMS\ClientHelperBundle\Helper\Elasticsearch\ClientRequestManager;
+use EMS\CommonBundle\Elasticsearch\Response\Response;
 use Symfony\Component\HttpFoundation\Request;
 
 class Manager
@@ -34,43 +35,17 @@ class Manager
         $search->setFrom($requestSearch->getFrom());
         $search->setSize($requestSearch->getSize());
 
-        $results = $this->clientRequest->commonSearch($search)->getResponse()->getData();
-
-        if (isset($results['aggregations'])) {
-            $requestSearch->bindAggregations($results['aggregations'], $qbService->getQueryFilters());
-        }
+        $response = Response::fromResultSet($this->clientRequest->commonSearch($search));
+        $requestSearch->bindAggregations($response, $qbService->getQueryFilters());
 
         return [
-            'results' => $results,
+            'results' => $response,
             'search' => $requestSearch,
             'query' => $requestSearch->getQueryString(),
             'sort' => $requestSearch->getSortBy(),
             'facets' => $requestSearch->getQueryFacets(),
             'page' => $requestSearch->getPage(),
             'size' => $requestSearch->getSize(),
-            'counters' => $this->getCountInfo($results),
         ];
-    }
-
-    /**
-     * @param array<mixed> $results
-     *
-     * @return array<int|string, array>
-     */
-    private function getCountInfo(array $results): array
-    {
-        $counters = [];
-        $aggregations = $results['aggregations'] ?? [];
-
-        foreach ($aggregations as $type => $data) {
-            $counters[$type] = [];
-            $buckets = $data['buckets'] ?? [];
-
-            foreach ($buckets as $bucket) {
-                $counters[$type][$bucket['key']] = $bucket['doc_count'];
-            }
-        }
-
-        return $counters;
     }
 }

--- a/src/Helper/Search/Search.php
+++ b/src/Helper/Search/Search.php
@@ -4,6 +4,7 @@ namespace EMS\ClientHelperBundle\Helper\Search;
 
 use Elastica\Query\AbstractQuery;
 use EMS\ClientHelperBundle\Helper\Elasticsearch\ClientRequest;
+use EMS\CommonBundle\Elasticsearch\Response\Response;
 use Symfony\Component\HttpFoundation\Request;
 
 class Search
@@ -92,14 +93,11 @@ class Search
         }
     }
 
-    /**
-     * @param array<mixed> $aggregations
-     */
-    public function bindAggregations(array $aggregations, ?AbstractQuery $queryFilters): void
+    public function bindAggregations(Response $response, ?AbstractQuery $queryFilters): void
     {
-        foreach ($aggregations as $name => $aggregation) {
-            if ($this->hasFilter($name)) {
-                $this->getFilter($name)->handleAggregation($aggregation, $this->getTypes(), $queryFilters);
+        foreach ($response->getAggregations() as $aggregation) {
+            if ($this->hasFilter($aggregation->getName())) {
+                $this->getFilter($aggregation->getName())->handleAggregation($aggregation->getRaw(), $this->getTypes(), $queryFilters);
             }
         }
     }


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |y|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

1. Improved contentType helper exception no connection
2. fix: search results become es response object:

BC in the templates results.hits.total becomes results.total
BC in the templates results.hits becomes results.documents
Remove the countInfo, we should use the search object in our templates

Deps:
https://github.com/ems-project/EMSCommonBundle/pull/209