### PR TITLE
[Fix] emsch assets use alias

### DIFF
--- a/src/Helper/Asset/AssetHelperRuntime.php
+++ b/src/Helper/Asset/AssetHelperRuntime.php
@@ -34,7 +34,7 @@ class AssetHelperRuntime implements RuntimeExtensionInterface
         $directory = $basePath.$hash;
 
         try {
-            $cacheKey = $this->manager->getDefault()->getCacheKey();
+            $cacheKey = $this->manager->getDefault()->getAlias();
             $symlink = $basePath.$cacheKey;
 
             if ($this->filesystem->exists($symlink.\DIRECTORY_SEPARATOR.$hash)) {


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

When using multiple environments with the same alias, it is wrong to use the environment name.

The symlink **/bundles/emsch_assets** should go to /example_live not live-nl.
```
{
  "live-nl": { "regex": "/.*-nl.*/", "alias": "example_live", "request": {"_locale": "nl"}},
  "live-en": { "regex": "/.*-en.*/", "alias": "example_live", "request": { "_locale": "en"}}
}
```