### PR TITLE
feat: add a immutable option and support array config to emsch.contro…

### DIFF
--- a/doc/routing.md
+++ b/doc/routing.md
@@ -25,6 +25,8 @@ In Twig you can set/override the pdf options with custom meta tags in the head s
 ```
 
 ## Route to an asset
+
+A route may also directly returns an asset:
 ```json
 {
     "path": "/{_locale}/example-pdf/{filename}",
@@ -35,6 +37,8 @@ In Twig you can set/override the pdf options with custom meta tags in the head s
 }
 ```
 
+The template must returns a json like this one:
+
 ```json
 {
   "hash": "aaaaabbbbbcccccdddd111112222",
@@ -44,5 +48,23 @@ In Twig you can set/override the pdf options with custom meta tags in the head s
   },
   "filename": "demo.pdf"
 
+}
+```
+
+ - `hash`: Asset's hash
+ - `config`: Config's hash or config array (see common's processor config)
+ - `filename`: File name
+
+This json may also contain an optional `immutable` boolean option [default value = false]:
+
+```json
+{
+  "hash": "aaaaabbbbbcccccdddd111112222",
+  "config": {
+    "_mime_type": "application/pdf",
+    "_disposition": "inline"
+  },
+  "filename": "demo.pdf",
+  "immutable": true
 }
 ```

--- a/src/Controller/RouterController.php
+++ b/src/Controller/RouterController.php
@@ -56,7 +56,13 @@ class RouterController
 
         $data = \json_decode($json, true);
 
-        return $this->processor->getResponse($request, $data['hash'], $data['config'], $data['filename']);
+        if (\is_string($data['config'] ?? false)) {
+            return $this->processor->getResponse($request, $data['hash'], $data['config'], $data['filename'], $data['immutable'] ?? false);
+        }
+
+        $config = $this->processor->configFactory($data['hash'], $data['config'] ?? []);
+
+        return $this->processor->getStreamedResponse($request, $config, $data['filename'], $data['immutable'] ?? false);
     }
 
     public function makeResponse(Request $request): Response


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |N|
|New feature?   |Y|	
|BC breaks?     |N|	
|Deprecations?  |N|	
|Fixed tickets  |N|	

- [X] New immutable option to the emsch.controller.router:asset controller method
- [X] The emsch.controller.router:asset controller method alose supports array as asset config  (not only a config hash)