### PR TITLE
fix: $results not defined => $results['hits']['total'] is always set …

### DIFF
--- a/src/Helper/Search/Manager.php
+++ b/src/Helper/Search/Manager.php
@@ -37,7 +37,7 @@ class Manager
 
         $commonSearch = $this->clientRequest->commonSearch($search);
         $results = $commonSearch->getResponse()->getData();
-        $results['hits']['total'] = $response['hits']['total']['value'] ?? $response['hits']['total'] ?? 0;
+        $results['hits']['total'] = $results['hits']['total']['value'] ?? $results['hits']['total'] ?? 0;
 
         $response = Response::fromResultSet($commonSearch);
         $requestSearch->bindAggregations($response, $qbService->getQueryFilters());


### PR DESCRIPTION
…to 0

|Q              |A  |
|---------------|---|
|Bug fix?       |Y|
|New feature?   |N|	
|BC breaks?     |N|	
|Deprecations?  |N|	
|Fixed tickets  |N|	

The search counter is alway set to zero