### PR TITLE
fix: local static templates and translations

### DIFF
--- a/src/Helper/Local/LocalEnvironment.php
+++ b/src/Helper/Local/LocalEnvironment.php
@@ -23,7 +23,7 @@ final class LocalEnvironment
     public function __construct(Environment $environment, string $path)
     {
         $this->environment = $environment;
-        $this->directory = $path.\DIRECTORY_SEPARATOR.$environment->getName();
+        $this->directory = $path.\DIRECTORY_SEPARATOR.$environment->getAlias();
         $this->fileSystem = new Filesystem();
     }
 

--- a/src/Helper/Routing/RoutingFile.php
+++ b/src/Helper/Routing/RoutingFile.php
@@ -46,7 +46,9 @@ final class RoutingFile implements \Countable
         foreach ($documents as $document) {
             $data = $document->getDataSource();
             if (isset($data['template_static'])) {
-                $data['template_static'] = $templatesFile->getByEmsName($data['template_static'])->getPathName();
+                $templateFile = $templatesFile->findStatic($data['template_static']);
+
+                $data['template_static'] = $templateFile ? $templateFile->getPathName() : $data['template_static'];
             }
 
             if (isset($data['config'])) {

--- a/src/Helper/Routing/RoutingFile.php
+++ b/src/Helper/Routing/RoutingFile.php
@@ -47,7 +47,6 @@ final class RoutingFile implements \Countable
             $data = $document->getDataSource();
             if (isset($data['template_static'])) {
                 $templateFile = $templatesFile->findStatic($data['template_static']);
-
                 $data['template_static'] = $templateFile ? $templateFile->getPathName() : $data['template_static'];
             }
 
@@ -75,8 +74,8 @@ final class RoutingFile implements \Countable
 
         foreach ($this->routes as $name => $route) {
             if (isset($route['template_static'])) {
-                $template = $this->templateFiles->getByName($route['template_static']);
-                if ($template->hasOuuid()) {
+                $template = $this->templateFiles->findStatic($route['template_static']);
+                if ($template && $template->hasOuuid()) {
                     $route['template_static'] = $template->getPathOuuid();
                 }
             }
@@ -99,7 +98,8 @@ final class RoutingFile implements \Countable
     {
         foreach ($this->routes as $name => $data) {
             if (isset($data['template_static'])) {
-                $data['template_static'] = $this->templateFiles->getByName($data['template_static'])->getPathName();
+                $template = $this->templateFiles->findStatic($data['template_static']);
+                $data['template_static'] = $template ? $template->getPathName() : $data['template_static'];
             }
 
             yield Route::fromData($name, $data);

--- a/src/Helper/Templating/TemplateFiles.php
+++ b/src/Helper/Templating/TemplateFiles.php
@@ -90,14 +90,14 @@ final class TemplateFiles implements \IteratorAggregate, \Countable
         throw new \RuntimeException(\sprintf('Could not find template "%s"', $name));
     }
 
-    public function getByEmsName(string $emsName): TemplateFile
+    public function findStatic(string $search): ?TemplateFile
     {
         foreach ($this->templateFiles as $templateFile) {
-            if ($emsName === $templateFile->getPathOuuid()) {
+            if ($search === $templateFile->getPathOuuid() || $search === $templateFile->getPathName()) {
                 return $templateFile;
             }
         }
 
-        throw new \RuntimeException(\sprintf('Could not find template "%s"', $emsName));
+        return null;
     }
 }

--- a/src/Helper/Translation/TranslationBuilder.php
+++ b/src/Helper/Translation/TranslationBuilder.php
@@ -15,7 +15,7 @@ final class TranslationBuilder extends AbstractBuilder
     /**
      * @return \Generator|MessageCatalogue[]
      */
-    public function buildMessageCatalogues(Environment $environment): \Generator
+    public function buildMessageCatalogues(Environment $environment, string $domain = null): \Generator
     {
         if (null === $contentType = $this->getContentType($environment)) {
             return [];
@@ -23,7 +23,7 @@ final class TranslationBuilder extends AbstractBuilder
 
         foreach ($this->getMessages($contentType) as $locale => $messages) {
             $messageCatalogue = new MessageCatalogue($locale);
-            $messageCatalogue->add($messages, $environment->getName());
+            $messageCatalogue->add($messages, $domain ?? $environment->getName());
 
             yield $messageCatalogue;
         }
@@ -31,7 +31,7 @@ final class TranslationBuilder extends AbstractBuilder
 
     public function buildFiles(Environment $environment, string $directory): void
     {
-        $messageCatalogues = $this->buildMessageCatalogues($environment);
+        $messageCatalogues = $this->buildMessageCatalogues($environment, 'messages');
 
         TranslationFiles::build($directory, $messageCatalogues);
     }

--- a/src/Helper/Translation/TranslationFile.php
+++ b/src/Helper/Translation/TranslationFile.php
@@ -12,7 +12,6 @@ final class TranslationFile implements \Countable
     public string $resource;
     public string $format;
     public string $locale;
-    public string $domain;
 
     public function __construct(SplFileInfo $file)
     {
@@ -21,7 +20,6 @@ final class TranslationFile implements \Countable
 
         $this->format = \array_pop($fileNameParts);
         $this->locale = \array_pop($fileNameParts);
-        $this->domain = \implode('.', $fileNameParts);
         $this->resource = $file->getPathname();
     }
 

--- a/src/Helper/Translation/Translator.php
+++ b/src/Helper/Translation/Translator.php
@@ -32,7 +32,7 @@ final class Translator implements CacheWarmerInterface
 
         if ($environment->isLocalPulled()) {
             foreach ($environment->getLocal()->getTranslations() as $file) {
-                $this->translator->addResource($file->format, $file->resource, $file->locale, $file->domain);
+                $this->translator->addResource($file->format, $file->resource, $file->locale, $environment->getName());
             }
 
             return;


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

# Fixes
## Allow all static templates 
> Not all elasticms use dataLink for static template on route.
> Allow just text because even route attributes can be used in resolving the template.
> Example: 'template/search_results.%_format%.twig'