### PR TITLE
fix: search filter value array replace

### DIFF
--- a/src/Helper/Search/Filter.php
+++ b/src/Helper/Search/Filter.php
@@ -169,9 +169,17 @@ final class Filter
         if (null !== $this->field) {
             $this->field = RequestHelper::replace($request, $this->field);
         }
+
         if (null !== $this->value) {
-            $this->value = RequestHelper::replace($request, $this->value);
+            if (\is_array($this->value)) {
+                $this->value = \array_map(function ($v) use ($request) {
+                    return \is_string($v) ? RequestHelper::replace($request, $v) : $v;
+                }, $this->value);
+            } elseif (\is_string($this->value)) {
+                $this->value = RequestHelper::replace($request, $this->value);
+            }
         }
+
         $requestValue = $request->get($this->name);
 
         if ($this->public && $requestValue) {


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

Only replace string filter values or array with strings

Argument 2 passed to
EMS\ClientHelperBundle\Helper\Request\RequestHelper::replace() must be
of the type string, array given