### PR TITLE
fix: search locale

### DIFF
--- a/src/Helper/Request/RequestHelper.php
+++ b/src/Helper/Request/RequestHelper.php
@@ -12,6 +12,8 @@ final class RequestHelper
 
     public static function replace(Request $request, string $subject): string
     {
+        $subject = self::replaceLocale($subject, $request->getLocale());
+
         $result = \preg_replace_callback(self::PATTERN, function ($match) use ($request) {
             return $request->get($match['parameter'], $match[0]);
         }, $subject);
@@ -21,5 +23,16 @@ final class RequestHelper
         }
 
         return $result;
+    }
+
+    private static function replaceLocale(string $subject, string $locale): string
+    {
+        if (\strpos($subject, '%locale%')) {
+            @\trigger_error('%locale% is deprecated please use %_locale%', E_USER_DEPRECATED);
+
+            return \str_replace('%locale%', $locale, $subject);
+        }
+
+        return $subject;
     }
 }

--- a/src/Helper/Search/Manager.php
+++ b/src/Helper/Search/Manager.php
@@ -28,8 +28,7 @@ final class Manager
      */
     public function search(Request $request): array
     {
-        $requestSearch = new Search($this->clientRequest);
-        $requestSearch->bindRequest($request);
+        $requestSearch = new Search($request, $this->clientRequest);
 
         $qbService = new QueryBuilder($this->clientRequest, $requestSearch);
         $search = $qbService->buildSearch($requestSearch->getTypes());

--- a/src/Helper/Search/Search.php
+++ b/src/Helper/Search/Search.php
@@ -71,7 +71,7 @@ final class Search
             'en' => 'english',
             'de' => 'german',
         ]), $clientRequest->getLocale());
-        $this->setSynonyms(($options['synonyms'] ?? []), $clientRequest->getLocale());
+        $this->setSynonyms(($options['synonyms'] ?? []));
 
         $filters = $options['filters'] ?? [];
         foreach ($filters as $name => $options) {
@@ -399,14 +399,14 @@ final class Search
     /**
      * @param array<mixed> $synonyms
      */
-    private function setSynonyms(array $synonyms, string $locale): void
+    private function setSynonyms(array $synonyms): void
     {
         foreach ($synonyms as $options) {
             if (\is_string($options)) {
                 $options = ['types' => [$options]];
             }
 
-            $this->synonyms[] = new Synonym($options, $locale);
+            $this->synonyms[] = new Synonym($this->request, $options);
         }
     }
 }

--- a/src/Helper/Search/Search.php
+++ b/src/Helper/Search/Search.php
@@ -12,6 +12,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 final class Search
 {
+    private Request $request;
     private ?string $indexRegex;
     /** @var string[] */
     private array $types;
@@ -45,8 +46,9 @@ final class Search
     private string $analyzer;
     private string $sortOrder = 'asc';
 
-    public function __construct(ClientRequest $clientRequest)
+    public function __construct(Request $request, ClientRequest $clientRequest)
     {
+        $this->request = $request;
         $options = $this->getOptions($clientRequest);
 
         if (isset($options['facets'])) {
@@ -75,6 +77,8 @@ final class Search
         foreach ($filters as $name => $options) {
             $this->filters[$name] = new Filter($clientRequest, $name, $options);
         }
+
+        $this->bindRequest($request);
     }
 
     public function bindRequest(Request $request): void

--- a/src/Helper/Search/Synonym.php
+++ b/src/Helper/Search/Synonym.php
@@ -7,33 +7,33 @@ namespace EMS\ClientHelperBundle\Helper\Search;
 use Elastica\Query\AbstractQuery;
 use Elastica\Query\BoolQuery;
 use Elastica\Query\Terms;
+use EMS\ClientHelperBundle\Helper\Request\RequestHelper;
 use EMS\CommonBundle\Elasticsearch\Document\EMSSource;
+use Symfony\Component\HttpFoundation\Request;
 
 final class Synonym
 {
     /** @var string[] */
-    private $types;
-    /** @var string|null */
-    private $field;
-    /** @var string|null */
-    private $searchField;
+    private array $types;
+    private ?string $field;
+    private ?string $searchField;
     /** @var array<mixed> */
-    private $filter;
+    private array $filter;
 
     /**
      * @param array{types: ?string[], field: ?string, search: ?string, } $data
      */
-    public function __construct(array $data, string $locale)
+    public function __construct(Request $request, array $data)
     {
         $this->types = $data['types'] ?? [];
         $this->filter = $data['filter'] ?? [];
 
         if (isset($data['field'])) {
-            $this->field = \str_replace('%locale%', $locale, $data['field']);
+            $this->field = RequestHelper::replace($request, $data['field']);
         }
 
         if (isset($data['search'])) {
-            $this->searchField = \str_replace('%locale%', $locale, $data['search']);
+            $this->searchField = RequestHelper::replace($request, $data['search']);
         }
     }
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -92,6 +92,7 @@
         </service>
         <service id="emsch.twig.runtime.client_request" class="EMS\ClientHelperBundle\Helper\Elasticsearch\ClientRequestRuntime">
             <argument type="service" id="emsch.manager.client_request" />
+            <argument type="service" id="request_stack" />
             <argument type="service" id="logger" />
             <tag name="monolog.logger" channel="emsch_request"/>
             <tag name="twig.runtime" />


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

The search is now still replacing by %locale%. We should use the new RequestHelper for this.
Inject the request in the search construct and make the bindRequest function private.
