### PR TITLE
chore: SearchController should not extend AbstractController

### DIFF
--- a/src/Controller/SearchController.php
+++ b/src/Controller/SearchController.php
@@ -7,12 +7,11 @@ namespace EMS\ClientHelperBundle\Controller;
 use EMS\ClientHelperBundle\Helper\Cache\CacheHelper;
 use EMS\ClientHelperBundle\Helper\Request\Handler;
 use EMS\ClientHelperBundle\Helper\Search\Manager;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Twig\Environment;
 
-final class SearchController extends AbstractController
+final class SearchController
 {
     private Manager $manager;
     private Handler $handler;


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

User Deprecated: Auto-injection of the container for "emsch.controller.search" is deprecated since Symfony 4.2. Configure it as a service instead.