### PR TITLE
fix: search index request from request

### DIFF
--- a/src/Helper/Search/Search.php
+++ b/src/Helper/Search/Search.php
@@ -97,7 +97,8 @@ final class Search
         $this->setSortOrder($request->get('o', $this->sortOrder));
 
         if (null !== $this->indexRegex) {
-            $this->indexRegex = RequestHelper::replace($request, $this->indexRegex);
+            $requestSearchIndex = RequestHelper::replace($request, $this->indexRegex);
+            $this->indexRegex = RequestHelper::replace($request, $requestSearchIndex);
         }
 
         foreach ($this->filters as $filter) {


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |Y|
|New feature?   |N|	
|BC breaks?     |N|	
|Deprecations?  |N|	
|Fixed tickets  |N|	

In the env variables you could say:
EMSCH_SEARCH_CONFIG='{"index_regex":"%search_index%","types": .... }

On your request you can do:
search:
    config:
        path: '/test/{year}/search'
        defaults: { search_index: test_search_%year% }

So we need a double call with the requestHelper::replace.