### PR TITLE
refactor: use ems_asset_path to generate asset path (not hard coded url)

### DIFF
--- a/src/DependencyInjection/EMSClientHelperExtension.php
+++ b/src/DependencyInjection/EMSClientHelperExtension.php
@@ -39,7 +39,7 @@ final class EMSClientHelperExtension extends Extension
 
         $templates = $config['templates'];
         $container->getDefinition('emsch.helper_exception')->replaceArgument(4, $templates['error']);
-        $container->getDefinition('emsch.routing.url.transformer')->replaceArgument(4, $templates['ems_link']);
+        $container->getDefinition('emsch.routing.url.transformer')->replaceArgument(5, $templates['ems_link']);
 
         $this->processElasticms($container, $loader, $config['elasticms']);
         $this->processApi($container, $config['api']);

--- a/src/Resources/config/routing.xml
+++ b/src/Resources/config/routing.xml
@@ -48,6 +48,7 @@
             <argument type="service" id="Symfony\Component\Routing\RouterInterface" />
         </service>
         <service id="emsch.routing.url.transformer" class="EMS\ClientHelperBundle\Helper\Routing\Url\Transformer">
+            <argument type="service" id="ems_common.twig.runtime.request"/>
             <argument type="service" id="emsch.manager.client_request"/>
             <argument type="service" id="emsch.routing.url.generator" />
             <argument type="service" id="twig" />


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |Y|
|New feature?   |Y|	
|BC breaks?     |N|	
|Deprecations?  |N|	
|Fixed tickets  |N|	

Refactor the url used for asset links in WYSIWYG field 