### PR TITLE
fix: empty filter

### DIFF
--- a/src/Helper/Search/Filter.php
+++ b/src/Helper/Search/Filter.php
@@ -185,6 +185,9 @@ final class Filter
         }
 
         $requestValue = $request->get($this->name, false);
+        if (\is_array($requestValue) && 1 === \count($requestValue) && '' === ($requestValue[0] ?? false)) {
+            $requestValue = false;
+        }
         if (false !== $requestValue) {
             $this->active = true;
         }


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

If a filter contains only one item with an empty string, it should works as a not defined filter