### PR TITLE
fix: search config as array

### DIFF
--- a/doc/routing.md
+++ b/doc/routing.md
@@ -15,6 +15,7 @@ For enabling pdf generation use the **emsch.controller.pdf** controller
 In Twig you can set/override the pdf options with custom meta tags in the head section
 ```html
 <head>
+    <title>Title</title>
     <meta name="pdf:filename" content="example.pdf" />
     <meta name="pdf:attachment" content="true" />
     <meta name="pdf:compress" content="true" />
@@ -162,4 +163,24 @@ This setup only works with php-fpm (no windows) because we continue the process 
 > Internally, the HttpKernel makes use of the fastcgi_finish_request PHP function. This means that at the moment, only the PHP FPM server API is able to send a response to the client while the server's PHP process still performs some tasks. With all other server APIs, listeners to kernel.terminate are still executed, but the response is not sent to the client until they are all completed.
 
 
+## Search route
 
+See the [search documentation](./search.md) fo more information.
+
+I.e.:
+````yaml
+emsch_search:
+    config:
+        path: { en: search, fr: chercher, nl: zoeken, de: suche }
+        defaults: {
+           search_config:{
+             "types": ["page", "publication", "slideshow"],
+             "fields": ["_all"],
+             "sizes": [10],
+             "sorts": {
+               "recent": {"field": "published_date", "order": "desc", "unmapped_type": "date", "missing":  "_last"}
+             }
+           }
+        }
+        controller: 'emsch.controller.search::handle'
+````

--- a/doc/search.md
+++ b/doc/search.md
@@ -213,7 +213,7 @@ will search and match with the **_all** field.
 }
 ````
 
-## Highhight
+## Highlight
 
 Get highlighted snippets from one or more fields in your search 
 ````json
@@ -234,3 +234,30 @@ Get highlighted snippets from one or more fields in your search
   }
 }
 ````
+
+## Routes with specific search config
+
+A route can specify its own search config by adding a search_config request attribute:
+
+I.e. in the routes.yml files:
+````yaml
+emsch_search:
+    config:
+        path: { en: search, fr: chercher, nl: zoeken, de: suche }
+        defaults: {
+           search_config:{
+             "types": ["page", "publication", "slideshow"],
+             "fields": ["_all"],
+             "sizes": [10],
+             "sorts": {
+               "recent": {"field": "published_date", "order": "desc", "unmapped_type": "date", "missing":  "_last"}
+             }
+           }
+        }
+        controller: 'emsch.controller.search::handle'
+````
+
+This approach can be very useful in development mode as you don't have to restart your application to test another search config.
+
+
+

--- a/src/Helper/Search/Search.php
+++ b/src/Helper/Search/Search.php
@@ -286,6 +286,7 @@ final class Search
             if (\is_array($requestSearchConfig)) {
                 return $requestSearchConfig;
             }
+            @\trigger_error('Deprecated search_config as string, please define it as an object in your route\'s config', E_USER_DEPRECATED);
 
             return Json::decode($requestSearchConfig);
         }

--- a/src/Helper/Search/Search.php
+++ b/src/Helper/Search/Search.php
@@ -283,6 +283,10 @@ final class Search
     private function getOptions(Request $request, ClientRequest $clientRequest): array
     {
         if ($requestSearchConfig = $request->get('search_config')) {
+            if (\is_array($requestSearchConfig)) {
+                return $requestSearchConfig;
+            }
+
             return Json::decode($requestSearchConfig);
         }
 


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

Allow route search_config as array (not only a JSON encoded string)