### PR TITLE
fix: router log

### DIFF
--- a/src/Helper/Routing/Router.php
+++ b/src/Helper/Routing/Router.php
@@ -21,7 +21,7 @@ final class Router extends BaseRouter implements VersatileGeneratorInterface
 
     public function supports($name): bool
     {
-        return 0 === \preg_match('/^(_profiler|_wdt).*$/s', $name);
+        return null !== $this->getRouteCollection()->get($name);
     }
 
     /**


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

When using the clientHelperBundle for channels insides elasticms, we recieve to many "unable to generate route" logs.

```
Router EMS\ClientHelperBundle\Helper\Routing\Router was unable to generate route. Reason: 'Route 'emsco_job_status' not found': Unable to generate a URL for the named route "...." as such route does not exist.
```